### PR TITLE
Add simulator

### DIFF
--- a/sim.py
+++ b/sim.py
@@ -1,0 +1,25 @@
+import matplotlib.pyplot as plt
+from mpl_toolkits import mplot3d
+plt.style.use("dark_background")
+
+coords = list(map(eval, open("Python/coords.txt").readlines()))
+x = list(c[0] for c in coords)
+y = list(c[1] for c in coords)
+z = list(c[2] for c in coords)
+
+class board:
+    D18 = None
+
+class neopixel:
+    class NeoPixel:
+        def __init__(self, _pin, n, *args, **kwargs):
+            self.pixels = [(0, 0, 0)] * n
+            self.ax = plt.axes(projection="3d")
+        
+        def __setitem__(self, index, color):
+            self.pixels[index] = (color[1] / 255.0, color[0] / 255.0, color[2] / 255.0, 1)
+
+        def show(self):
+            self.ax.scatter(x, y, z, c=self.pixels)
+            plt.pause(1 / 1000)
+            self.ax.cla()


### PR DESCRIPTION
I've already seen 2 pull request for "animation viewer" or "preview" features to make it easier to write animations.
Having looked at both in my opinion they're not very good, both are *very* slow to update and either require running in a web browser or significant modifications to the original code.

This pull request implements a better solution, it:
- is self contained in a seperate file of only 25 lines
- performs better than other implementations
- is a drop in replacement for hardware neopixel, only requiring you to change 2 imports
- does not modify the original code at all

To use it you just need to change 2 lines of code:
```python
    # use real leds
    import board
    import neopixel
    
    # use simulator
    from sim import board
    from sim import neopixel
```