### PR TITLE
Make colors RGB again

### DIFF
--- a/xmaslights-spin.py
+++ b/xmaslights-spin.py
@@ -1,8 +1,6 @@
 def xmaslight():
     # This is the code from my 
     
-    #NOTE THE LEDS ARE GRB COLOUR (NOT RGB)
-    
     # Here are the libraries I am currently using:
     import time
     import board
@@ -40,7 +38,7 @@ def xmaslight():
     #set up the pixels (AKA 'LEDs')
     PIXEL_COUNT = len(coords) # this should be 500
     
-    pixels = neopixel.NeoPixel(board.D18, PIXEL_COUNT, auto_write=False)
+    pixels = neopixel.NeoPixel(board.D18, PIXEL_COUNT, auto_write=False, pixel_order=neopixel.RGB)
     
     
     # YOU CAN EDIT FROM HERE DOWN
@@ -70,9 +68,9 @@ def xmaslight():
     # how much the angle changes per cycle
     inc = 0.1
     
-    # the two colours in GRB order
+    # the colours are in RGB order
     # if you are turning a lot of them on at once, keep their brightness down please
-    colourA = [0,50,50] # purple
+    colourA = [50,0,50] # purple
     colourB = [50,50,0] # yellow
     
     


### PR DESCRIPTION
The hardware never considered the lights to be in GRB order. However,
there was something else going on. Basically, the library is written to
always allow you to specify colors in RGB order, but it can then write
those colors to the lights in different orders (mainly RGB or GRB) and
for some reason, by default it assumes your LEDs take the colors in GRB
order.

As such, it was rewriting the RGB colors to GRB format, even though the
LEDs actually took them in RGB order, which made the colors wrong.
Writing the colors as GRB is the opposite of this, so it undoes the
change, making it seem that's the right way to specify the colors.

By just telling the library that the LEDs are taking the colors in RGB
order, you can specify the colors the way you normally do: RGB.